### PR TITLE
DE: -moz-force-broken-image-icon: alt text on height OR width set

### DIFF
--- a/files/de/web/css/-moz-force-broken-image-icon/index.md
+++ b/files/de/web/css/-moz-force-broken-image-icon/index.md
@@ -52,7 +52,7 @@ img {
 {{EmbedLiveSample('Examples','125','125')}}
 
 > [!NOTE]
-> Es sei denn, das Bild hat eine spezifizierte Höhe und Breite, wird das `alt`-Attribut nicht angezeigt, wenn `-moz-force-broken-image-icon` auf `1` gesetzt ist.
+> Wenn `-moz-force-broken-image-icon` auf `1` gesetzt ist, wird das `alt`-Attribut nicht angezeigt, wenn das Bild eine spezifizierte Höhe oder Breite hat.
 
 ## Hinweise
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

before: if height and width is set
after: if height **or** width is set

### Motivation

translated change for https://github.com/mdn/content/pull/37261, for content change explanation, see over there.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
**Depends on:** https://github.com/mdn/content/pull/37261


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
