### PR TITLE
fix(de): fix typo

### DIFF
--- a/files/de/web/html/element/form/index.md
+++ b/files/de/web/html/element/form/index.md
@@ -1,5 +1,5 @@
 ---
-title: "<form>: Das Formulard-Element"
+title: "<form>: Das Formular-Element"
 slug: Web/HTML/Element/form
 l10n:
   sourceCommit: 5b20f5f4265f988f80f513db0e4b35c7e0cd70dc


### PR DESCRIPTION
"Form" in German is "Formular" (not "Formulard")

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Looks like there is a typo ("Formulard" instead of "Formular").

### Motivation

Fix a typo.

### Additional details

./.

### Related issues and pull requests

./.