### PR TITLE
fix(workflows/pr-test): do not use pull_request_target

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -7,11 +7,7 @@
 name: PR Test
 
 on:
-  # The `GITHUB_TOKEN` in workflows triggered by the `pull_request_target` event
-  # is granted read/write repository access.
-  # Please pay attention to limit the permissions of each job!
-  # https://docs.github.com/actions/using-jobs/assigning-permissions-to-jobs
-  pull_request_target:
+  pull_request:
     branches:
       - main
 
@@ -25,8 +21,6 @@ jobs:
     # Set the permissions to `read-all`, preventing the workflow from
     # any accidental write access to the repository.
     permissions: read-all
-    outputs:
-      has_assets: ${{ steps.build-content.outputs.has_assets }}
     env:
       BASE_SHA: ${{ github.event.pull_request.base.sha }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -37,8 +31,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: "${{ env.HEAD_SHA }}"
 
       - name: Get changed files
         run: |
@@ -132,9 +124,6 @@ jobs:
           # be able to use this raw diff file for the benefit of analyzing.
           wget https://github.com/${{ github.repository }}/compare/${BASE_SHA}...${HEAD_SHA}.diff -O ${BUILD_OUT_ROOT}/DIFF
 
-          # Set the output variable so the next job could skip if there are no assets
-          echo "has_assets=true" >> "$GITHUB_OUTPUT"
-
       - name: Merge static assets with built documents
         if: env.GIT_DIFF_CONTENT
         run: |
@@ -159,13 +148,3 @@ jobs:
           echo ${GIT_DIFF_FILES}
 
           yarn filecheck ${GIT_DIFF_FILES}
-
-#  review:
-#    needs: tests
-#    if: needs.tests.outputs.has_assets
-#    # write permissions are required to create a comment in the corresponding PR
-#    permissions: write-all
-#    uses: ./.github/workflows/pr-review-companion.yml
-#    # inherit the secrets from the parent workflow
-#    # https://docs.github.com/actions/using-workflows/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow
-#    secrets: inherit


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Migrates the `pr-test` workflow from `pull_request_target` to `pull_request`.

This was already done for mdn/content in April 2024, and for mdn/translated-content in January 2025:

- https://github.com/mdn/content/pull/33003
- https://github.com/mdn/translated-content/pull/25578

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
