### PR TITLE
fix(workflows): disable cache in privileged workflows

### DIFF
--- a/.github/workflows/auto-cleanup-bot.yml
+++ b/.github/workflows/auto-cleanup-bot.yml
@@ -33,8 +33,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
-          cache: yarn
-          cache-dependency-path: "**/yarn.lock"
 
       - name: Install all yarn packages
         run: |

--- a/.github/workflows/sync-translated-content.yml
+++ b/.github/workflows/sync-translated-content.yml
@@ -49,8 +49,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: "mdn/yari/.nvmrc"
-          cache: "yarn"
-          cache-dependency-path: mdn/yari/yarn.lock
 
       - name: Install (yari)
         working-directory: ${{ github.workspace }}/mdn/yari


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Disables the cache (used by `actions/setup-node`) in privileged workflows.

### Motivation

Limits the impact of less-privileged workflows that may be vulnerable to code injection.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Same as: https://github.com/mdn/content/pull/39547
