### PR TITLE
fix(actions): use bash array instead of relying on xargs

### DIFF
--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -134,7 +134,7 @@ jobs:
           for file in "${files_to_lint[@]}"; do
               absolute_paths+=("$(realpath -e "$file")")
           done
-          FM_LINT_LOG=$(cd ${{ github.workspace }}/mdn/content && yarn fix:fm --config-file ${{ github.workspace }}/front-matter-config.json "${absolute_paths[@]}" 2>&1) || FM_LINT_FAILED=true
+          FM_LINT_LOG=$(cd ${{ github.workspace }}/mdn/content && yarn fix:fm --config-file ${{ github.workspace }}/.front-matter-config.json "${absolute_paths[@]}" 2>&1) || FM_LINT_FAILED=true
           echo "FM_LINT_LOG<<${EOF}" >> "$GITHUB_OUTPUT"
           echo "${FM_LINT_LOG}" >> "$GITHUB_OUTPUT"
           echo "${EOF}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -33,21 +33,34 @@ jobs:
         run: |
           # Use the GitHub API to get the list of changed files
           # documentation: https://docs.github.com/rest/commits/commits#compare-two-commits
-          DIFF_DOCUMENTS=$(gh api repos/{owner}/{repo}/compare/${BASE_SHA}...${HEAD_SHA} \
-            --jq '.files | .[] | select(.status|IN("added", "modified", "renamed", "copied", "changed")) | .filename')
-          # filter out files that are not markdown
-          DIFF_DOCUMENTS=$(echo "${DIFF_DOCUMENTS}" | egrep -i ".*\.md$" | xargs)
-          echo "DIFF_DOCUMENTS=${DIFF_DOCUMENTS}" >> $GITHUB_OUTPUT
+
+          # Get files as newline-separated list
+          FILTERED_FILES=$(gh api repos/{owner}/{repo}/compare/${BASE_SHA}...${HEAD_SHA} \
+            --jq '.files | .[] | select(.status|IN("added", "modified", "renamed", "copied", "changed")) | .filename' | \
+            egrep -i "^files/.*\.md$")
+
+          # Store as multiline output
+          EOF="$(openssl rand -hex 8)"
+          echo "DIFF_DOCUMENTS<<${EOF}" >> "$GITHUB_OUTPUT"
+          echo "${FILTERED_FILES}" >> "$GITHUB_OUTPUT"
+          echo "${EOF}" >> "$GITHUB_OUTPUT"
+
+          # Also set a simple flag for whether we have files
+          if [ -n "${FILTERED_MD_FILES// /}" ]; then  # Remove all spaces and check if anything remains
+            echo "HAS_FILES=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "HAS_FILES=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Checkout HEAD
-        if: steps.check.outputs.DIFF_DOCUMENTS
+        if: steps.check.outputs.HAS_FILES == 'true'
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: pr_head
 
       - name: Get changed content from HEAD
-        if: steps.check.outputs.DIFF_DOCUMENTS
+        if: steps.check.outputs.HAS_FILES == 'true'
         run: |
           git config --global user.email "108879845+mdn-bot@users.noreply.github.com"
           git config --global user.name "mdn-bot"
@@ -63,13 +76,13 @@ jobs:
           git commit -m "Code from PR head"
 
       - uses: actions/checkout@v4
-        if: steps.check.outputs.DIFF_DOCUMENTS
+        if: steps.check.outputs.HAS_FILES == 'true'
         with:
           repository: mdn/content
           path: mdn/content
 
       - name: Setup Node.js environment
-        if: steps.check.outputs.DIFF_DOCUMENTS
+        if: steps.check.outputs.HAS_FILES == 'true'
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
@@ -79,11 +92,11 @@ jobs:
             yarn.lock
 
       - name: Install all yarn packages for mdn/translated-content-de
-        if: steps.check.outputs.DIFF_DOCUMENTS
+        if: steps.check.outputs.HAS_FILES == 'true'
         run: yarn --frozen-lockfile
 
       - name: Install all yarn packages for mdn/content
-        if: steps.check.outputs.DIFF_DOCUMENTS
+        if: steps.check.outputs.HAS_FILES == 'true'
         working-directory: ${{ github.workspace }}/mdn/content
         run: yarn --frozen-lockfile
         env:
@@ -92,17 +105,23 @@ jobs:
 
       - name: Lint and format markdown files
         id: lint
-        if: steps.check.outputs.DIFF_DOCUMENTS
+        if: steps.check.outputs.HAS_FILES == 'true'
         run: |
           # Generate random delimiter
           # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
           EOF="$(openssl rand -hex 8)"
 
-          files_to_lint="${DIFF_DOCUMENTS}"
+          # The DIFF_DOCUMENTS env var contains the clean newline-separated list
+          # Read into array, one filename per line
+          readarray -t files_to_lint <<< "$DIFF_DOCUMENTS"
+
+          # Debug: show what we got
+          printf "Files to process (%d files):\n" "${#files_to_lint[@]}"
+          printf "'%s'\n" "${files_to_lint[@]}"
 
           echo "Running markdownlint --fix"
           MD_LINT_FAILED=false
-          MD_LINT_LOG=$(yarn markdownlint-cli2 --fix ${files_to_lint} 2>&1) || MD_LINT_FAILED=true
+          MD_LINT_LOG=$(yarn markdownlint-cli2 --fix "${files_to_lint[@]}" 2>&1) || MD_LINT_FAILED=true
           echo "MD_LINT_LOG<<${EOF}" >> "$GITHUB_OUTPUT"
           echo "${MD_LINT_LOG}" >> "$GITHUB_OUTPUT"
           echo "${EOF}" >> "$GITHUB_OUTPUT"
@@ -111,21 +130,24 @@ jobs:
           echo "Linting front-matter"
           FM_LINT_FAILED=false
           # absolute_paths is needed because front-matter linter is run from mdn/content directory
-          absolute_paths=$(echo "${files_to_lint}" | xargs realpath -e | xargs)
-          FM_LINT_LOG=$(cd ${{ github.workspace }}/mdn/content && yarn fix:fm --config-file ${{ github.workspace }}/front-matter-config.json ${absolute_paths} 2>&1) || FM_LINT_FAILED=true
+          absolute_paths=()
+          for file in "${files_to_lint[@]}"; do
+              absolute_paths+=("$(realpath -e "$file")")
+          done
+          FM_LINT_LOG=$(cd ${{ github.workspace }}/mdn/content && yarn fix:fm --config-file ${{ github.workspace }}/front-matter-config.json "${absolute_paths[@]}" 2>&1) || FM_LINT_FAILED=true
           echo "FM_LINT_LOG<<${EOF}" >> "$GITHUB_OUTPUT"
           echo "${FM_LINT_LOG}" >> "$GITHUB_OUTPUT"
           echo "${EOF}" >> "$GITHUB_OUTPUT"
           echo "FM_LINT_FAILED=${FM_LINT_FAILED}" >> "$GITHUB_OUTPUT"
 
           echo "Running url locale checker"
-          node ./scripts/check-url-locale.js --fix ${files_to_lint}
+          node ./scripts/check-url-locale.js --fix "${files_to_lint[@]}"
 
           echo "Running autocorrect"
-          yarn autocorrect --fix ${files_to_lint}
+          yarn autocorrect --fix "${files_to_lint[@]}"
 
           echo "Running Prettier"
-          yarn prettier -w ${files_to_lint}
+          yarn prettier -w "${files_to_lint[@]}"
 
           if [[ -n $(git diff) ]]; then
             echo "FILES_MODIFIED=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -36,29 +36,55 @@ jobs:
         id: check
         run: |
           # Use the GitHub API to get the list of changed files
-          # documentation: https://docs.github.com/rest/commits/commits#compare-two-commits
           DIFF_DOCUMENTS=$(gh api repos/{owner}/{repo}/compare/${BASE_SHA}...${HEAD_SHA} \
             --jq '.files | .[] | select(.status|IN("added", "modified", "renamed", "copied", "changed")) | .filename')
 
-          # filter out files that are not markdown files
-          GIT_DIFF_CONTENT=$(echo "${DIFF_DOCUMENTS}" | egrep -i "^files/.*\.md$" | xargs)
-          echo "GIT_DIFF_CONTENT=${GIT_DIFF_CONTENT}" >> $GITHUB_OUTPUT"
+          FILTERED_MD_FILES=$(echo "$DIFF_DOCUMENTS" | egrep -i "^files/.*\.md$" || true)
+          FILTERED_IMAGE_FILES=$(echo "$DIFF_DOCUMENTS" | egrep -i "^files/.*\.(png|jpeg|jpg|gif|svg|webp)$" || true)
 
-          # filter out files that are not attachments
-          # note that we should get the absolute path of the changed attachments
-          GIT_DIFF_FILES=$(echo "${DIFF_DOCUMENTS}" | egrep -i "^files/.*\.(png|jpeg|jpg|gif|svg|webp)$" | xargs readlink -e | xargs)
-          echo "GIT_DIFF_FILES=${GIT_DIFF_FILES}" >> $GITHUB_OUTPUT"
+          HAS_MD_FILES=false
+          HAS_IMAGE_FILES=false
+
+          # Check if we actually have content (not just empty strings)
+          if [ -n "${FILTERED_MD_FILES// /}" ]; then  # Remove all spaces and check if anything remains
+            HAS_MD_FILES=true
+            EOF_MD="$(openssl rand -hex 8)"
+            echo "GIT_DIFF_CONTENT<<${EOF_MD}" >> "$GITHUB_OUTPUT"
+            echo "${FILTERED_MD_FILES}" >> "$GITHUB_OUTPUT"
+            echo "${EOF_MD}" >> "$GITHUB_OUTPUT"
+          else
+            echo "GIT_DIFF_CONTENT=" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ -n "${FILTERED_IMAGE_FILES// /}" ]; then  # Remove all spaces and check if anything remains
+            HAS_IMAGE_FILES=true
+            EOF_IMG="$(openssl rand -hex 8)"
+            echo "GIT_DIFF_FILES<<${EOF_IMG}" >> "$GITHUB_OUTPUT"
+            echo "${FILTERED_IMAGE_FILES}" >> "$GITHUB_OUTPUT"
+            echo "${EOF_IMG}" >> "$GITHUB_OUTPUT"
+          else
+            echo "GIT_DIFF_FILES=" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Set the boolean outputs
+          echo "HAS_MD_FILES=${HAS_MD_FILES}" >> "$GITHUB_OUTPUT"
+          echo "HAS_IMAGE_FILES=${HAS_IMAGE_FILES}" >> "$GITHUB_OUTPUT"
+          if [ "${HAS_MD_FILES}" = "true" ] || [ "${HAS_IMAGE_FILES}" = "true" ]; then
+            echo "HAS_FILES=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "HAS_FILES=false" >> "$GITHUB_OUTPUT"
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v4
-        if: steps.check.outputs.GIT_DIFF_CONTENT || steps.check.outputs.GIT_DIFF_FILES
+        if: steps.check.outputs.HAS_FILES == 'true'
         with:
           repository: mdn/content
           path: mdn/content
 
       - name: Setup Node.js environment
-        if: steps.check.outputs.GIT_DIFF_CONTENT || steps.check.outputs.GIT_DIFF_FILES
+        if: steps.check.outputs.HAS_FILES == 'true'
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
@@ -66,7 +92,7 @@ jobs:
           cache-dependency-path: mdn/content/yarn.lock
 
       - name: Install all yarn packages
-        if: steps.check.outputs.GIT_DIFF_CONTENT || steps.check.outputs.GIT_DIFF_FILES
+        if: steps.check.outputs.HAS_FILES == 'true'
         working-directory: ${{ github.workspace }}/mdn/content
         run: yarn --frozen-lockfile
         env:
@@ -75,7 +101,7 @@ jobs:
 
       - name: Build changed content
         id: build-content
-        if: steps.check.outputs.GIT_DIFF_CONTENT
+        if: steps.check.outputs.HAS_MD_FILES == 'true'
         env:
           CONTENT_ROOT: ${{ github.workspace }}/mdn/content/files
           CONTENT_TRANSLATED_ROOT: ${{ github.workspace }}/files
@@ -109,9 +135,17 @@ jobs:
         run: |
           mkdir -p ${BUILD_OUT_ROOT}
 
+          # Read into array, one filename per line
+          readarray -t files_to_build <<< "$GIT_DIFF_CONTENT"
+
+          ARGS=()
+          for file in "${files_to_build[@]}"; do
+            ARGS+=("-f" "$PWD/$file")
+          done
+
           # Don't use `yarn build` (from mdn/content) because that one hardcodes
           # the BUILD_OUT_ROOT and CONTENT_ROOT env vars.
-          node node_modules/@mdn/yari/build/cli.js ${GIT_DIFF_CONTENT}
+          node node_modules/@mdn/yari/build/cli.js "${files_to_build[@]}"
 
           echo "Disk usage size of build"
           du -sh ${BUILD_OUT_ROOT}
@@ -126,7 +160,7 @@ jobs:
           wget https://github.com/${{ github.repository }}/compare/${BASE_SHA}...${HEAD_SHA}.diff -O ${BUILD_OUT_ROOT}/DIFF
 
       - name: Merge static assets with built documents
-        if: steps.check.outputs.GIT_DIFF_CONTENT
+        if: steps.check.outputs.HAS_MD_FILES == 'true'
         run: |
           # Exclude the .map files, as they're used for debugging JS and CSS.
           rsync -a --exclude "*.map" ${{ github.workspace }}/mdn/content/node_modules/@mdn/yari/client/build/ ${BUILD_OUT_ROOT}
@@ -134,7 +168,7 @@ jobs:
           du -sh ${BUILD_OUT_ROOT}
 
       - uses: actions/upload-artifact@v4
-        if: steps.check.outputs.GIT_DIFF_CONTENT
+        if: steps.check.outputs.HAS_MD_FILES == 'true'
         with:
           name: build
           path: ${{ env.BUILD_OUT_ROOT }}
@@ -146,6 +180,6 @@ jobs:
           CONTENT_TRANSLATED_ROOT: ${{ github.workspace }}/files
         working-directory: ${{ github.workspace }}/mdn/content
         run: |
-          echo ${GIT_DIFF_FILES}
+          readarray -t files_to_check <<< "$GIT_DIFF_FILES"
 
-          yarn filecheck ${GIT_DIFF_FILES}
+          yarn filecheck "${files_to_check[@]}"


### PR DESCRIPTION
### Description

Replaces the use of `xargs` in github actions with a bash array

### Motivation

`xargs` usage considered harmful

### Additional details

File names with special characters an spaces caused the action to fail.

### Related issues and pull requests

Fixes [this issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1980970)