### PR TITLE
ci(pr-check-lint_content): fix typo in env variable

### DIFF
--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -46,7 +46,7 @@ jobs:
           echo "${EOF}" >> "$GITHUB_OUTPUT"
 
           # Also set a simple flag for whether we have files
-          if [ -n "${FILTERED_MD_FILES// /}" ]; then  # Remove all spaces and check if anything remains
+          if [ -n "${FILTERED_FILES// /}" ]; then  # Remove all spaces and check if anything remains
             echo "HAS_FILES=true" >> "$GITHUB_OUTPUT"
           else
             echo "HAS_FILES=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fixes a typo in an environment variable.

### Motivation

This caused the the workflow to always skip linting, as if there were no files to lint.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Same as:

- https://github.com/mdn/content/pull/40831
