### PR TITLE
ci(workflows): disable `actions/checkout` credential persistance

### DIFF
--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout BASE
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Get changed files
         id: check
@@ -58,6 +60,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: pr_head
+          persist-credentials: false
 
       - name: Get changed content from HEAD
         if: steps.check.outputs.HAS_FILES == 'true'

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           repository: mdn/translated-content-de
           path: mdn/translated-content-de
+          persist-credentials: false
 
       - name: Get changed files
         id: check
@@ -88,6 +89,7 @@ jobs:
         with:
           repository: mdn/content
           path: mdn/content
+          persist-credentials: false
 
       - name: Checkout (translated-content)
         uses: actions/checkout@v5
@@ -95,6 +97,7 @@ jobs:
         with:
           repository: mdn/translated-content
           path: mdn/translated-content
+          persist-credentials: false
 
       - name: Move de into translated-content
         if: steps.check.outputs.HAS_FILES == 'true'

--- a/.github/workflows/sync-translated-content.yml
+++ b/.github/workflows/sync-translated-content.yml
@@ -33,17 +33,20 @@ jobs:
           repository: mdn/yari
           path: mdn/yari
           ref: test-de
+          persist-credentials: false
 
       - name: Checkout (content)
         uses: actions/checkout@v5
         with:
           repository: mdn/content
           path: mdn/content
+          persist-credentials: false
 
       - name: Checkout (translated-content-de)
         uses: actions/checkout@v5
         with:
           path: mdn/translated-content-de
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description
  
Adds `persist-credentials: false` to all `actions/checkout` workflow steps.

## Motivation

Applies security best practices. It prevents persistance of the `GITHUB_TOKEN` in the local git config.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/883.
