### PR TITLE
ci(pr-test): use fred

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -25,7 +25,7 @@ jobs:
       BASE_SHA: ${{ github.event.pull_request.base.sha }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       # If we don't do this the built files will end up in
-      # `node_modules/@mdn/yari/client/build/` and we don't want that
+      # `node_modules/@mdn/fred/out/` and we don't want that
       # to get pushed into the cache.
       BUILD_OUT_ROOT: /tmp/build
 
@@ -147,28 +147,19 @@ jobs:
           # information about the flaws when we analyze the built PR.
           BUILD_FLAW_LEVELS: "unsafe_html: error, *:warn"
 
-          # Because we build these pages in a way that you get a toolbar,
-          # so the flaws can be displayed, but we don't want any of the
-          # other toolbar features like "Fix fixable flaws" or "Quick-edit"
-          # we set this to disable that stuff.
-          REACT_APP_CRUD_MODE_READONLY: true
-
           BUILD_LIVE_SAMPLES_BASE_URL: https://live.mdnyalp.dev
           BUILD_LEGACY_LIVE_SAMPLES_BASE_URL: https://live-samples.mdn.allizom.net
-
-          # In these builds, we never care for or need the ability to sign in.
-          # This environment variable will disable that functionality entirely.
-          REACT_APP_DISABLE_AUTH: true
 
           # TODO: This should be implicit when `CI=true`
           BUILD_NO_PROGRESSBAR: true
 
-          # Playground
-          REACT_APP_PLAYGROUND_BASE_HOST: mdnyalp.dev
+          # fred
+          FRED_WRITER_MODE: true
+          FRED_PLAYGROUND_BASE_HOST: mdnyalp.dev
 
           # rari
           LIVE_SAMPLES_BASE_URL: https://live.mdnyalp.dev
-          INTERACTIVE_EXAMPLES_BASE_URL: https://interactive-examples.mdn.allizom.ne
+          INTERACTIVE_EXAMPLES_BASE_URL: https://interactive-examples.mdn.allizom.net
           ADDITIONAL_LOCALES_FOR_GENERICS_AND_SPAS: de
         working-directory: ${{ github.workspace }}/mdn/content
         run: |
@@ -189,7 +180,9 @@ jobs:
           done
 
           yarn rari build --no-basic --json-issues --data-issues "${ARGS[@]}"
-          yarn yari-render-html
+
+          cp -vR node_modules/@mdn/fred/out/. "$BUILD_OUT_ROOT"
+          yarn fred-ssr
 
           echo "Disk usage size of the build"
           du -sh $BUILD_OUT_ROOT
@@ -203,13 +196,9 @@ jobs:
           # be able to use this raw diff file for the benefit of analyzing.
           wget https://github.com/${{ github.repository }}/compare/${BASE_SHA}...${HEAD_SHA}.diff -O ${BUILD_OUT_ROOT}/DIFF
 
-      - name: Merge static assets with built documents
+      - name: Show final disk usage size of build
         if: steps.check.outputs.HAS_MD_FILES == 'true'
-        run: |
-          # Exclude the .map files, as they're used for debugging JS and CSS.
-          rsync -a --exclude "*.map" "${{ github.workspace }}/mdn/content/node_modules/@mdn/yari/client/build/" ${BUILD_OUT_ROOT}
-          # Show the final disk usage size of the build.
-          du -sh ${BUILD_OUT_ROOT}
+        run: du -sh $BUILD_OUT_ROOT
 
       - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         if: steps.check.outputs.HAS_MD_FILES == 'true'


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Updates the `pr-test` workflow to use fred instead of yari.

### Motivation

This should ensure that the tests can pass again.

### Additional details

Ports the following changes from translated-content:

- https://github.com/mdn/translated-content/pull/28697
- https://github.com/mdn/translated-content/pull/29283
- https://github.com/mdn/translated-content/pull/29741

Test run with 66653b47d23b61bc6e5c4f8be35a7cddc4f6c18f: https://github.com/mdn/translated-content-de/actions/runs/19330020912/job/55290495524?pr=152

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/667.
