### PR TITLE
chore(de): remove backticks from title

### DIFF
--- a/files/de/mdn/writing_guidelines/page_structures/page_types/page_type_key/index.md
+++ b/files/de/mdn/writing_guidelines/page_structures/page_types/page_type_key/index.md
@@ -1,5 +1,5 @@
 ---
-title: Der `page-type` Front Matter Schlüssel
+title: Der page-type Front Matter Schlüssel
 slug: MDN/Writing_guidelines/Page_structures/Page_types/Page_type_key
 l10n:
   sourceCommit: 85fccefc8066bd49af4ddafc12c77f35265c7e2d

--- a/files/de/web/accessibility/aria/reference/roles/banner_role/index.md
+++ b/files/de/web/accessibility/aria/reference/roles/banner_role/index.md
@@ -1,5 +1,5 @@
 ---
-title: "ARIA: `banner`-Rolle"
+title: "ARIA: banner-Rolle"
 short-title: banner
 slug: Web/Accessibility/ARIA/Reference/Roles/banner_role
 l10n:

--- a/files/de/web/accessibility/aria/reference/roles/combobox_role/index.md
+++ b/files/de/web/accessibility/aria/reference/roles/combobox_role/index.md
@@ -1,5 +1,5 @@
 ---
-title: "ARIA: Rolle `combobox`"
+title: "ARIA: Rolle combobox"
 short-title: combobox
 slug: Web/Accessibility/ARIA/Reference/Roles/combobox_role
 l10n:

--- a/files/de/web/accessibility/aria/reference/roles/contentinfo_role/index.md
+++ b/files/de/web/accessibility/aria/reference/roles/contentinfo_role/index.md
@@ -1,5 +1,5 @@
 ---
-title: "ARIA: `contentinfo`-Rolle"
+title: "ARIA: contentinfo-Rolle"
 short-title: contentinfo
 slug: Web/Accessibility/ARIA/Reference/Roles/contentinfo_role
 l10n:

--- a/files/de/web/accessibility/aria/reference/roles/definition_role/index.md
+++ b/files/de/web/accessibility/aria/reference/roles/definition_role/index.md
@@ -1,5 +1,5 @@
 ---
-title: "ARIA: Rolle `definition`"
+title: "ARIA: Rolle definition"
 short-title: definition
 slug: Web/Accessibility/ARIA/Reference/Roles/definition_role
 l10n:

--- a/files/de/web/accessibility/aria/reference/roles/form_role/index.md
+++ b/files/de/web/accessibility/aria/reference/roles/form_role/index.md
@@ -1,5 +1,5 @@
 ---
-title: "ARIA: Rollenmerkmal `form`"
+title: "ARIA: Rollenmerkmal form"
 short-title: form
 slug: Web/Accessibility/ARIA/Reference/Roles/form_role
 l10n:

--- a/files/de/web/accessibility/aria/reference/roles/math_role/index.md
+++ b/files/de/web/accessibility/aria/reference/roles/math_role/index.md
@@ -1,5 +1,5 @@
 ---
-title: "ARIA: Rolle `math`"
+title: "ARIA: Rolle math"
 short-title: math
 slug: Web/Accessibility/ARIA/Reference/Roles/math_role
 l10n:

--- a/files/de/web/accessibility/aria/reference/roles/menuitem_role/index.md
+++ b/files/de/web/accessibility/aria/reference/roles/menuitem_role/index.md
@@ -1,5 +1,5 @@
 ---
-title: "ARIA: Rolle `menuitem`"
+title: "ARIA: Rolle menuitem"
 short-title: menuitem
 slug: Web/Accessibility/ARIA/Reference/Roles/menuitem_role
 l10n:

--- a/files/de/web/accessibility/aria/reference/roles/meter_role/index.md
+++ b/files/de/web/accessibility/aria/reference/roles/meter_role/index.md
@@ -1,5 +1,5 @@
 ---
-title: "ARIA: Rolle `meter`"
+title: "ARIA: Rolle meter"
 short-title: meter
 slug: Web/Accessibility/ARIA/Reference/Roles/meter_role
 l10n:

--- a/files/de/web/accessibility/aria/reference/roles/separator_role/index.md
+++ b/files/de/web/accessibility/aria/reference/roles/separator_role/index.md
@@ -1,5 +1,5 @@
 ---
-title: "ARIA: `separator`-Rolle"
+title: "ARIA: separator-Rolle"
 short-title: separator
 slug: Web/Accessibility/ARIA/Reference/Roles/separator_role
 l10n:

--- a/files/de/web/accessibility/aria/reference/roles/structure_role/index.md
+++ b/files/de/web/accessibility/aria/reference/roles/structure_role/index.md
@@ -1,5 +1,5 @@
 ---
-title: "ARIA: `structure`-Rolle"
+title: "ARIA: structure-Rolle"
 short-title: structure
 slug: Web/Accessibility/ARIA/Reference/Roles/structure_role
 l10n:

--- a/files/de/web/accessibility/aria/reference/roles/toolbar_role/index.md
+++ b/files/de/web/accessibility/aria/reference/roles/toolbar_role/index.md
@@ -1,5 +1,5 @@
 ---
-title: "ARIA: Rolle `toolbar`"
+title: "ARIA: Rolle toolbar"
 short-title: toolbar
 slug: Web/Accessibility/ARIA/Reference/Roles/toolbar_role
 l10n:

--- a/files/de/web/accessibility/aria/reference/roles/treeitem_role/index.md
+++ b/files/de/web/accessibility/aria/reference/roles/treeitem_role/index.md
@@ -1,5 +1,5 @@
 ---
-title: "ARIA: Rollenbeschreibung `treeitem`"
+title: "ARIA: Rollenbeschreibung treeitem"
 short-title: treeitem
 slug: Web/Accessibility/ARIA/Reference/Roles/treeitem_role
 l10n:

--- a/files/de/web/api/animation/effect/index.md
+++ b/files/de/web/api/animation/effect/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Animation: `effect`-Eigenschaft"
+title: "Animation: effect-Eigenschaft"
 short-title: effect
 slug: Web/API/Animation/effect
 l10n:

--- a/files/de/web/api/audiocontext/outputlatency/index.md
+++ b/files/de/web/api/audiocontext/outputlatency/index.md
@@ -1,5 +1,5 @@
 ---
-title: "AudioContext: Eigenschaft `outputLatency`"
+title: "AudioContext: Eigenschaft outputLatency"
 short-title: outputLatency
 slug: Web/API/AudioContext/outputLatency
 l10n:

--- a/files/de/web/api/backgroundfetchmanager/fetch/index.md
+++ b/files/de/web/api/backgroundfetchmanager/fetch/index.md
@@ -1,5 +1,5 @@
 ---
-title: "BackgroundFetchManager: `fetch()` Methode"
+title: "BackgroundFetchManager: fetch() Methode"
 short-title: fetch()
 slug: Web/API/BackgroundFetchManager/fetch
 l10n:

--- a/files/de/web/api/cache/add/index.md
+++ b/files/de/web/api/cache/add/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Cache: `add()` Methode"
+title: "Cache: add() Methode"
 short-title: add()
 slug: Web/API/Cache/add
 l10n:

--- a/files/de/web/api/credentialscontainer/create/index.md
+++ b/files/de/web/api/credentialscontainer/create/index.md
@@ -1,5 +1,5 @@
 ---
-title: "CredentialsContainer: `create()`-Methode"
+title: "CredentialsContainer: create()-Methode"
 short-title: create()
 slug: Web/API/CredentialsContainer/create
 l10n:

--- a/files/de/web/api/cryptokey/usages/index.md
+++ b/files/de/web/api/cryptokey/usages/index.md
@@ -1,5 +1,5 @@
 ---
-title: "CryptoKey: `usages`-Eigenschaft"
+title: "CryptoKey: usages-Eigenschaft"
 short-title: usages
 slug: Web/API/CryptoKey/usages
 l10n:

--- a/files/de/web/api/cssfunctionrule/getparameters/index.md
+++ b/files/de/web/api/cssfunctionrule/getparameters/index.md
@@ -1,5 +1,5 @@
 ---
-title: "CSSFunctionRule: `getParameters()`-Methode"
+title: "CSSFunctionRule: getParameters()-Methode"
 short-title: getParameters()
 slug: Web/API/CSSFunctionRule/getParameters
 l10n:

--- a/files/de/web/api/cssnesteddeclarations/style/index.md
+++ b/files/de/web/api/cssnesteddeclarations/style/index.md
@@ -1,5 +1,5 @@
 ---
-title: "CSSNestedDeclarations: Eigenschaft `style`"
+title: "CSSNestedDeclarations: Eigenschaft style"
 short-title: style
 slug: Web/API/CSSNestedDeclarations/style
 l10n:

--- a/files/de/web/api/cssnumericvalue/parse_static/index.md
+++ b/files/de/web/api/cssnumericvalue/parse_static/index.md
@@ -1,5 +1,5 @@
 ---
-title: "CSSNumericValue: `parse()` statische Methode"
+title: "CSSNumericValue: parse() statische Methode"
 short-title: parse()
 slug: Web/API/CSSNumericValue/parse_static
 l10n:

--- a/files/de/web/api/cssrule/parentstylesheet/index.md
+++ b/files/de/web/api/cssrule/parentstylesheet/index.md
@@ -1,5 +1,5 @@
 ---
-title: "CSSRule: Eigenschaft `parentStyleSheet`"
+title: "CSSRule: Eigenschaft parentStyleSheet"
 short-title: parentStyleSheet
 slug: Web/API/CSSRule/parentStyleSheet
 l10n:

--- a/files/de/web/api/cssstylesheet/replace/index.md
+++ b/files/de/web/api/cssstylesheet/replace/index.md
@@ -1,5 +1,5 @@
 ---
-title: "CSSStyleSheet: `replace()`-Methode"
+title: "CSSStyleSheet: replace()-Methode"
 short-title: replace()
 slug: Web/API/CSSStyleSheet/replace
 l10n:

--- a/files/de/web/api/cssstylevalue/parse_static/index.md
+++ b/files/de/web/api/cssstylevalue/parse_static/index.md
@@ -1,5 +1,5 @@
 ---
-title: "CSSStyleValue: `parse()` statische Methode"
+title: "CSSStyleValue: parse() statische Methode"
 short-title: parse()
 slug: Web/API/CSSStyleValue/parse_static
 l10n:

--- a/files/de/web/api/customelementregistry/define/index.md
+++ b/files/de/web/api/customelementregistry/define/index.md
@@ -1,5 +1,5 @@
 ---
-title: "CustomElementRegistry: `define()`-Methode"
+title: "CustomElementRegistry: define()-Methode"
 short-title: define()
 slug: Web/API/CustomElementRegistry/define
 l10n:

--- a/files/de/web/api/decompressionstream/readable/index.md
+++ b/files/de/web/api/decompressionstream/readable/index.md
@@ -1,5 +1,5 @@
 ---
-title: "DecompressionStream: `readable`-Eigenschaft"
+title: "DecompressionStream: readable-Eigenschaft"
 short-title: readable
 slug: Web/API/DecompressionStream/readable
 l10n:

--- a/files/de/web/api/document/afterscriptexecute_event/index.md
+++ b/files/de/web/api/document/afterscriptexecute_event/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Dokument: `afterscriptexecute`-Ereignis"
+title: "Dokument: afterscriptexecute-Ereignis"
 short-title: afterscriptexecute
 slug: Web/API/Document/afterscriptexecute_event
 l10n:

--- a/files/de/web/api/document/elementfrompoint/index.md
+++ b/files/de/web/api/document/elementfrompoint/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Dokument: `elementFromPoint()`-Methode"
+title: "Dokument: elementFromPoint()-Methode"
 short-title: elementFromPoint()
 slug: Web/API/Document/elementFromPoint
 l10n:

--- a/files/de/web/api/document/getelementsbytagname/index.md
+++ b/files/de/web/api/document/getelementsbytagname/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Dokument: `getElementsByTagName()` Methode"
+title: "Dokument: getElementsByTagName() Methode"
 short-title: getElementsByTagName()
 slug: Web/API/Document/getElementsByTagName
 l10n:

--- a/files/de/web/api/domtokenlist/item/index.md
+++ b/files/de/web/api/domtokenlist/item/index.md
@@ -1,5 +1,5 @@
 ---
-title: "DOMTokenList: `item()` Methode"
+title: "DOMTokenList: item() Methode"
 short-title: item()
 slug: Web/API/DOMTokenList/item
 l10n:

--- a/files/de/web/api/domtokenlist/values/index.md
+++ b/files/de/web/api/domtokenlist/values/index.md
@@ -1,5 +1,5 @@
 ---
-title: "DOMTokenList: `values()`-Methode"
+title: "DOMTokenList: values()-Methode"
 short-title: values()
 slug: Web/API/DOMTokenList/values
 l10n:

--- a/files/de/web/api/element/blur_event/index.md
+++ b/files/de/web/api/element/blur_event/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Element: `blur`-Ereignis"
+title: "Element: blur-Ereignis"
 short-title: blur
 slug: Web/API/Element/blur_event
 l10n:

--- a/files/de/web/api/element/pointermove_event/index.md
+++ b/files/de/web/api/element/pointermove_event/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Element: `pointermove`-Ereignis"
+title: "Element: pointermove-Ereignis"
 short-title: pointermove
 slug: Web/API/Element/pointermove_event
 l10n:

--- a/files/de/web/api/filesystemdirectoryhandle/entries/index.md
+++ b/files/de/web/api/filesystemdirectoryhandle/entries/index.md
@@ -1,5 +1,5 @@
 ---
-title: "FileSystemDirectoryHandle: `entries()`-Methode"
+title: "FileSystemDirectoryHandle: entries()-Methode"
 short-title: entries()
 slug: Web/API/FileSystemDirectoryHandle/entries
 l10n:

--- a/files/de/web/api/filesystemobserver/disconnect/index.md
+++ b/files/de/web/api/filesystemobserver/disconnect/index.md
@@ -1,5 +1,5 @@
 ---
-title: "FileSystemObserver: `disconnect()`-Methode"
+title: "FileSystemObserver: disconnect()-Methode"
 short-title: disconnect()
 slug: Web/API/FileSystemObserver/disconnect
 l10n:

--- a/files/de/web/api/filesystemsyncaccesshandle/read/index.md
+++ b/files/de/web/api/filesystemsyncaccesshandle/read/index.md
@@ -1,5 +1,5 @@
 ---
-title: "FileSystemSyncAccessHandle: `read()`-Methode"
+title: "FileSystemSyncAccessHandle: read()-Methode"
 short-title: read()
 slug: Web/API/FileSystemSyncAccessHandle/read
 l10n:

--- a/files/de/web/api/gamepad/hapticactuators/index.md
+++ b/files/de/web/api/gamepad/hapticactuators/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Gamepad: `hapticActuators`-Eigenschaft"
+title: "Gamepad: hapticActuators-Eigenschaft"
 short-title: hapticActuators
 slug: Web/API/Gamepad/hapticActuators
 l10n:

--- a/files/de/web/api/gpucommandencoder/label/index.md
+++ b/files/de/web/api/gpucommandencoder/label/index.md
@@ -1,5 +1,5 @@
 ---
-title: "GPUCommandEncoder: Eigentum `label`"
+title: "GPUCommandEncoder: Eigentum label"
 short-title: label
 slug: Web/API/GPUCommandEncoder/label
 l10n:

--- a/files/de/web/api/gpudevice/features/index.md
+++ b/files/de/web/api/gpudevice/features/index.md
@@ -1,5 +1,5 @@
 ---
-title: "GPUDevice: `features`-Eigenschaft"
+title: "GPUDevice: features-Eigenschaft"
 short-title: features
 slug: Web/API/GPUDevice/features
 l10n:

--- a/files/de/web/api/gpuqueue/label/index.md
+++ b/files/de/web/api/gpuqueue/label/index.md
@@ -1,5 +1,5 @@
 ---
-title: "GPUQueue: `label`-Eigenschaft"
+title: "GPUQueue: label-Eigenschaft"
 short-title: label
 slug: Web/API/GPUQueue/label
 l10n:

--- a/files/de/web/api/highlight/values/index.md
+++ b/files/de/web/api/highlight/values/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Highlight: Methode `values()`"
+title: "Highlight: Methode values()"
 short-title: values()
 slug: Web/API/Highlight/values
 l10n:

--- a/files/de/web/api/htmlcollection/item/index.md
+++ b/files/de/web/api/htmlcollection/item/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTMLCollection: `item()`-Methode"
+title: "HTMLCollection: item()-Methode"
 short-title: item()
 slug: Web/API/HTMLCollection/item
 l10n:

--- a/files/de/web/api/htmldialogelement/close/index.md
+++ b/files/de/web/api/htmldialogelement/close/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTMLDialogElement: `close()`-Methode"
+title: "HTMLDialogElement: close()-Methode"
 short-title: close()
 slug: Web/API/HTMLDialogElement/close
 l10n:

--- a/files/de/web/api/htmlelement/command_event/index.md
+++ b/files/de/web/api/htmlelement/command_event/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTMLElement: `command`-Ereignis"
+title: "HTMLElement: command-Ereignis"
 slug: Web/API/HTMLElement/command_event
 l10n:
   sourceCommit: f5e710f5c620c8d3c8b179f3b062d6bbdc8389ec

--- a/files/de/web/api/htmlinputelement/selectionchange_event/index.md
+++ b/files/de/web/api/htmlinputelement/selectionchange_event/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTMLInputElement: `selectionchange`-Ereignis"
+title: "HTMLInputElement: selectionchange-Ereignis"
 short-title: selectionchange
 slug: Web/API/HTMLInputElement/selectionchange_event
 l10n:

--- a/files/de/web/api/htmllinkelement/disabled/index.md
+++ b/files/de/web/api/htmllinkelement/disabled/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTMLLinkElement: Eigenschaft `disabled`"
+title: "HTMLLinkElement: Eigenschaft disabled"
 short-title: disabled
 slug: Web/API/HTMLLinkElement/disabled
 l10n:

--- a/files/de/web/api/htmlmediaelement/controlslist/index.md
+++ b/files/de/web/api/htmlmediaelement/controlslist/index.md
@@ -1,5 +1,5 @@
 ---
-title: "HTMLMediaElement: Eigenschaft `controlsList`"
+title: "HTMLMediaElement: Eigenschaft controlsList"
 short-title: controlsList
 slug: Web/API/HTMLMediaElement/controlsList
 l10n:

--- a/files/de/web/api/idledetector/requestpermission_static/index.md
+++ b/files/de/web/api/idledetector/requestpermission_static/index.md
@@ -1,5 +1,5 @@
 ---
-title: "IdleDetector: `requestPermission()` statische Methode"
+title: "IdleDetector: requestPermission() statische Methode"
 short-title: requestPermission()
 slug: Web/API/IdleDetector/requestPermission_static
 l10n:

--- a/files/de/web/api/keyboardlayoutmap/values/index.md
+++ b/files/de/web/api/keyboardlayoutmap/values/index.md
@@ -1,5 +1,5 @@
 ---
-title: "KeyboardLayoutMap: `values()`-Methode"
+title: "KeyboardLayoutMap: values()-Methode"
 short-title: values()
 slug: Web/API/KeyboardLayoutMap/values
 l10n:

--- a/files/de/web/api/languagedetector/create_static/index.md
+++ b/files/de/web/api/languagedetector/create_static/index.md
@@ -1,5 +1,5 @@
 ---
-title: "LanguageDetector: `create()` statische Methode"
+title: "LanguageDetector: create() statische Methode"
 short-title: create()
 slug: Web/API/LanguageDetector/create_static
 l10n:

--- a/files/de/web/api/mediakeystatusmap/entries/index.md
+++ b/files/de/web/api/mediakeystatusmap/entries/index.md
@@ -1,5 +1,5 @@
 ---
-title: "MediaKeyStatusMap: `entries()`-Methode"
+title: "MediaKeyStatusMap: entries()-Methode"
 short-title: entries()
 slug: Web/API/MediaKeyStatusMap/entries
 l10n:

--- a/files/de/web/api/mediatrackconstraints/framerate/index.md
+++ b/files/de/web/api/mediatrackconstraints/framerate/index.md
@@ -1,5 +1,5 @@
 ---
-title: "MediaTrackConstraints: `frameRate`-Eigenschaft"
+title: "MediaTrackConstraints: frameRate-Eigenschaft"
 short-title: frameRate
 slug: Web/API/MediaTrackConstraints/frameRate
 l10n:

--- a/files/de/web/api/mutationrecord/attributename/index.md
+++ b/files/de/web/api/mutationrecord/attributename/index.md
@@ -1,5 +1,5 @@
 ---
-title: "MutationRecord: `attributeName`-Eigenschaft"
+title: "MutationRecord: attributeName-Eigenschaft"
 short-title: attributeName
 slug: Web/API/MutationRecord/attributeName
 l10n:

--- a/files/de/web/api/navigation/entries/index.md
+++ b/files/de/web/api/navigation/entries/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Navigation: `entries()`-Methode"
+title: "Navigation: entries()-Methode"
 short-title: entries()
 slug: Web/API/Navigation/entries
 l10n:

--- a/files/de/web/api/navigator/contacts/index.md
+++ b/files/de/web/api/navigator/contacts/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Navigator: `contacts`-Eigenschaft"
+title: "Navigator: contacts-Eigenschaft"
 short-title: contacts
 slug: Web/API/Navigator/contacts
 l10n:

--- a/files/de/web/api/navigator/presentation/index.md
+++ b/files/de/web/api/navigator/presentation/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Navigator: `presentation`-Eigenschaft"
+title: "Navigator: presentation-Eigenschaft"
 short-title: presentation
 slug: Web/API/Navigator/presentation
 l10n:

--- a/files/de/web/api/nodelist/values/index.md
+++ b/files/de/web/api/nodelist/values/index.md
@@ -1,5 +1,5 @@
 ---
-title: "NodeList: `values()` Methode"
+title: "NodeList: values() Methode"
 short-title: values()
 slug: Web/API/NodeList/values
 l10n:

--- a/files/de/web/api/notification/requestpermission_static/index.md
+++ b/files/de/web/api/notification/requestpermission_static/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Benachrichtigung: `requestPermission()` statische Methode"
+title: "Benachrichtigung: requestPermission() statische Methode"
 short-title: requestPermission()
 slug: Web/API/Notification/requestPermission_static
 l10n:

--- a/files/de/web/api/performance/getentries/index.md
+++ b/files/de/web/api/performance/getentries/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Leistung: `getEntries()`-Methode"
+title: "Leistung: getEntries()-Methode"
 short-title: getEntries()
 slug: Web/API/Performance/getEntries
 l10n:

--- a/files/de/web/api/performance/getentriesbytype/index.md
+++ b/files/de/web/api/performance/getentriesbytype/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Performance: `getEntriesByType()` Methode"
+title: "Performance: getEntriesByType() Methode"
 short-title: getEntriesByType()
 slug: Web/API/Performance/getEntriesByType
 l10n:

--- a/files/de/web/api/performanceelementtiming/intersectionrect/index.md
+++ b/files/de/web/api/performanceelementtiming/intersectionrect/index.md
@@ -1,5 +1,5 @@
 ---
-title: "PerformanceElementTiming: `intersectionRect`-Eigenschaft"
+title: "PerformanceElementTiming: intersectionRect-Eigenschaft"
 short-title: intersectionRect
 slug: Web/API/PerformanceElementTiming/intersectionRect
 l10n:

--- a/files/de/web/api/permissions/query/index.md
+++ b/files/de/web/api/permissions/query/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Berechtigungen: `query()` Methode"
+title: "Berechtigungen: query() Methode"
 short-title: query()
 slug: Web/API/Permissions/query
 l10n:

--- a/files/de/web/api/permissions/revoke/index.md
+++ b/files/de/web/api/permissions/revoke/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Berechtigungen: `revoke()`-Methode"
+title: "Berechtigungen: revoke()-Methode"
 short-title: revoke()
 slug: Web/API/Permissions/revoke
 l10n:

--- a/files/de/web/api/pressureobserver/disconnect/index.md
+++ b/files/de/web/api/pressureobserver/disconnect/index.md
@@ -1,5 +1,5 @@
 ---
-title: "PressureObserver: `disconnect()`-Methode"
+title: "PressureObserver: disconnect()-Methode"
 short-title: disconnect()
 slug: Web/API/PressureObserver/disconnect
 l10n:

--- a/files/de/web/api/publickeycredential/signalallacceptedcredentials_static/index.md
+++ b/files/de/web/api/publickeycredential/signalallacceptedcredentials_static/index.md
@@ -1,5 +1,5 @@
 ---
-title: "PublicKeyCredential: `signalAllAcceptedCredentials()` statische Methode"
+title: "PublicKeyCredential: signalAllAcceptedCredentials() statische Methode"
 short-title: signalAllAcceptedCredentials()
 slug: Web/API/PublicKeyCredential/signalAllAcceptedCredentials_static
 l10n:

--- a/files/de/web/api/request/clone/index.md
+++ b/files/de/web/api/request/clone/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Anfrage: `clone()`-Methode"
+title: "Anfrage: clone()-Methode"
 short-title: clone()
 slug: Web/API/Request/clone
 l10n:

--- a/files/de/web/api/request/text/index.md
+++ b/files/de/web/api/request/text/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Anfrage: `text()` Methode"
+title: "Anfrage: text() Methode"
 short-title: text()
 slug: Web/API/Request/text
 l10n:

--- a/files/de/web/api/rtcicecandidatestats/priority/index.md
+++ b/files/de/web/api/rtcicecandidatestats/priority/index.md
@@ -1,5 +1,5 @@
 ---
-title: "RTCIceCandidateStats: `priority`-Eigenschaft"
+title: "RTCIceCandidateStats: priority-Eigenschaft"
 short-title: priority
 slug: Web/API/RTCIceCandidateStats/priority
 l10n:

--- a/files/de/web/api/serviceworkerregistration/periodicsync/index.md
+++ b/files/de/web/api/serviceworkerregistration/periodicsync/index.md
@@ -1,5 +1,5 @@
 ---
-title: "ServiceWorkerRegistration: Eigenschaft `periodicSync`"
+title: "ServiceWorkerRegistration: Eigenschaft periodicSync"
 short-title: periodicSync
 slug: Web/API/ServiceWorkerRegistration/periodicSync
 l10n:

--- a/files/de/web/api/shadowroot/innerhtml/index.md
+++ b/files/de/web/api/shadowroot/innerhtml/index.md
@@ -1,5 +1,5 @@
 ---
-title: "ShadowRoot: `innerHTML`-Eigenschaft"
+title: "ShadowRoot: innerHTML-Eigenschaft"
 short-title: innerHTML
 slug: Web/API/ShadowRoot/innerHTML
 l10n:

--- a/files/de/web/api/sharedstorageworkletglobalscope/register/index.md
+++ b/files/de/web/api/sharedstorageworkletglobalscope/register/index.md
@@ -1,5 +1,5 @@
 ---
-title: "SharedStorageWorkletGlobalScope: `register()`-Methode"
+title: "SharedStorageWorkletGlobalScope: register()-Methode"
 short-title: register()
 slug: Web/API/SharedStorageWorkletGlobalScope/register
 l10n:

--- a/files/de/web/api/speechrecognition/available_static/index.md
+++ b/files/de/web/api/speechrecognition/available_static/index.md
@@ -1,5 +1,5 @@
 ---
-title: "SpeechRecognition: `available()` statische Methode"
+title: "SpeechRecognition: available() statische Methode"
 short-title: available()
 slug: Web/API/SpeechRecognition/available_static
 l10n:

--- a/files/de/web/api/speechrecognition/install_static/index.md
+++ b/files/de/web/api/speechrecognition/install_static/index.md
@@ -1,5 +1,5 @@
 ---
-title: "SpeechRecognition: `install()` statische Methode"
+title: "SpeechRecognition: install() statische Methode"
 short-title: install()
 slug: Web/API/SpeechRecognition/install_static
 l10n:

--- a/files/de/web/api/speechrecognition/result_event/index.md
+++ b/files/de/web/api/speechrecognition/result_event/index.md
@@ -1,5 +1,5 @@
 ---
-title: "SpeechRecognition: `result` Ereignis"
+title: "SpeechRecognition: result Ereignis"
 short-title: result
 slug: Web/API/SpeechRecognition/result_event
 l10n:

--- a/files/de/web/api/speechrecognition/speechend_event/index.md
+++ b/files/de/web/api/speechrecognition/speechend_event/index.md
@@ -1,5 +1,5 @@
 ---
-title: "SpeechRecognition: `speechend`-Ereignis"
+title: "SpeechRecognition: speechend-Ereignis"
 short-title: speechend
 slug: Web/API/SpeechRecognition/speechend_event
 l10n:

--- a/files/de/web/api/stylepropertymapreadonly/has/index.md
+++ b/files/de/web/api/stylepropertymapreadonly/has/index.md
@@ -1,5 +1,5 @@
 ---
-title: "StylePropertyMapReadOnly: `has()`-Methode"
+title: "StylePropertyMapReadOnly: has()-Methode"
 short-title: has()
 slug: Web/API/StylePropertyMapReadOnly/has
 l10n:

--- a/files/de/web/api/summarizer/availability_static/index.md
+++ b/files/de/web/api/summarizer/availability_static/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Summarizer: `availability()` statische Methode"
+title: "Summarizer: availability() statische Methode"
 short-title: availability()
 slug: Web/API/Summarizer/availability_static
 l10n:

--- a/files/de/web/api/tasksignal/any_static/index.md
+++ b/files/de/web/api/tasksignal/any_static/index.md
@@ -1,5 +1,5 @@
 ---
-title: "TaskSignal: `any()` statische Methode"
+title: "TaskSignal: any() statische Methode"
 short-title: any()
 slug: Web/API/TaskSignal/any_static
 l10n:

--- a/files/de/web/api/textmetrics/ideographicbaseline/index.md
+++ b/files/de/web/api/textmetrics/ideographicbaseline/index.md
@@ -1,5 +1,5 @@
 ---
-title: "TextMetrics: Eigenschaft `ideographicBaseline`"
+title: "TextMetrics: Eigenschaft ideographicBaseline"
 short-title: ideographicBaseline
 slug: Web/API/TextMetrics/ideographicBaseline
 l10n:

--- a/files/de/web/api/urlsearchparams/append/index.md
+++ b/files/de/web/api/urlsearchparams/append/index.md
@@ -1,5 +1,5 @@
 ---
-title: "URLSearchParams: `append()` Methode"
+title: "URLSearchParams: append() Methode"
 short-title: append()
 slug: Web/API/URLSearchParams/append
 l10n:

--- a/files/de/web/api/validitystate/toolong/index.md
+++ b/files/de/web/api/validitystate/toolong/index.md
@@ -1,5 +1,5 @@
 ---
-title: "ValidityState: Eigenschaft `tooLong`"
+title: "ValidityState: Eigenschaft tooLong"
 short-title: tooLong
 slug: Web/API/ValidityState/tooLong
 l10n:

--- a/files/de/web/api/validitystate/valid/index.md
+++ b/files/de/web/api/validitystate/valid/index.md
@@ -1,5 +1,5 @@
 ---
-title: "ValidityState: Eigenschaft `valid`"
+title: "ValidityState: Eigenschaft valid"
 short-title: valid
 slug: Web/API/ValidityState/valid
 l10n:

--- a/files/de/web/api/videotrack/language/index.md
+++ b/files/de/web/api/videotrack/language/index.md
@@ -1,5 +1,5 @@
 ---
-title: "VideoTrack: `language`-Eigenschaft"
+title: "VideoTrack: language-Eigenschaft"
 short-title: language
 slug: Web/API/VideoTrack/language
 l10n:

--- a/files/de/web/api/videotrackgenerator/muted/index.md
+++ b/files/de/web/api/videotrackgenerator/muted/index.md
@@ -1,5 +1,5 @@
 ---
-title: "VideoTrackGenerator: `muted`-Eigenschaft"
+title: "VideoTrackGenerator: muted-Eigenschaft"
 short-title: muted
 slug: Web/API/VideoTrackGenerator/muted
 l10n:

--- a/files/de/web/api/webglrenderingcontext/uniformmatrix/index.md
+++ b/files/de/web/api/webglrenderingcontext/uniformmatrix/index.md
@@ -1,5 +1,5 @@
 ---
-title: "WebGLRenderingContext: `uniformMatrix[234]fv()` Methode"
+title: "WebGLRenderingContext: uniformMatrix[234]fv() Methode"
 short-title: uniformMatrix[234]fv()
 slug: Web/API/WebGLRenderingContext/uniformMatrix
 l10n:

--- a/files/de/web/api/webtransport/closed/index.md
+++ b/files/de/web/api/webtransport/closed/index.md
@@ -1,5 +1,5 @@
 ---
-title: "WebTransport: `closed`-Eigenschaft"
+title: "WebTransport: closed-Eigenschaft"
 short-title: closed
 slug: Web/API/WebTransport/closed
 l10n:

--- a/files/de/web/api/window/pageshow_event/index.md
+++ b/files/de/web/api/window/pageshow_event/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Window: `pageshow`-Ereignis"
+title: "Window: pageshow-Ereignis"
 short-title: pageshow
 slug: Web/API/Window/pageshow_event
 l10n:

--- a/files/de/web/api/windowclient/ancestororigins/index.md
+++ b/files/de/web/api/windowclient/ancestororigins/index.md
@@ -1,5 +1,5 @@
 ---
-title: "WindowClient: `ancestorOrigins`-Eigenschaft"
+title: "WindowClient: ancestorOrigins-Eigenschaft"
 short-title: ancestorOrigins
 slug: Web/API/WindowClient/ancestorOrigins
 l10n:

--- a/files/de/web/api/windowcontrolsoverlay/geometrychange_event/index.md
+++ b/files/de/web/api/windowcontrolsoverlay/geometrychange_event/index.md
@@ -1,5 +1,5 @@
 ---
-title: "WindowControlsOverlay: `geometrychange`-Ereignis"
+title: "WindowControlsOverlay: geometrychange-Ereignis"
 short-title: geometrychange
 slug: Web/API/WindowControlsOverlay/geometrychange_event
 l10n:

--- a/files/de/web/api/workletsharedstorage/length/index.md
+++ b/files/de/web/api/workletsharedstorage/length/index.md
@@ -1,5 +1,5 @@
 ---
-title: "WorkletSharedStorage: `length()` Methode"
+title: "WorkletSharedStorage: length() Methode"
 short-title: length()
 slug: Web/API/WorkletSharedStorage/length
 l10n:

--- a/files/de/web/api/writablestreamdefaultwriter/abort/index.md
+++ b/files/de/web/api/writablestreamdefaultwriter/abort/index.md
@@ -1,5 +1,5 @@
 ---
-title: "WritableStreamDefaultWriter: `abort()` Methode"
+title: "WritableStreamDefaultWriter: abort() Methode"
 short-title: abort()
 slug: Web/API/WritableStreamDefaultWriter/abort
 l10n:

--- a/files/de/web/api/xrcubelayer/redraw_event/index.md
+++ b/files/de/web/api/xrcubelayer/redraw_event/index.md
@@ -1,5 +1,5 @@
 ---
-title: "XRCubeLayer: `redraw`-Ereignis"
+title: "XRCubeLayer: redraw-Ereignis"
 short-title: redraw
 slug: Web/API/XRCubeLayer/redraw_event
 l10n:

--- a/files/de/web/api/xrframe/getdepthinformation/index.md
+++ b/files/de/web/api/xrframe/getdepthinformation/index.md
@@ -1,5 +1,5 @@
 ---
-title: "XRFrame: `getDepthInformation()` Methode"
+title: "XRFrame: getDepthInformation() Methode"
 short-title: getDepthInformation()
 slug: Web/API/XRFrame/getDepthInformation
 l10n:

--- a/files/de/web/api/xrview/projectionmatrix/index.md
+++ b/files/de/web/api/xrview/projectionmatrix/index.md
@@ -1,5 +1,5 @@
 ---
-title: "XRView: Eigenschaft `projectionMatrix`"
+title: "XRView: Eigenschaft projectionMatrix"
 short-title: projectionMatrix
 slug: Web/API/XRView/projectionMatrix
 l10n:

--- a/files/de/web/css/guides/images/using_object-view-box/index.md
+++ b/files/de/web/css/guides/images/using_object-view-box/index.md
@@ -1,5 +1,5 @@
 ---
-title: Verwendung der CSS-Eigenschaft `object-view-box`
+title: Verwendung der CSS-Eigenschaft object-view-box
 short-title: Verwendung von `object-view-box`
 slug: Web/CSS/Guides/Images/Using_object-view-box
 l10n:

--- a/files/de/web/html/reference/elements/audio/index.md
+++ b/files/de/web/html/reference/elements/audio/index.md
@@ -1,5 +1,5 @@
 ---
-title: "`<audio>`: Das Einbettungs-Element für Audio"
+title: "<audio>: Das Einbettungs-Element für Audio"
 slug: Web/HTML/Reference/Elements/audio
 l10n:
   sourceCommit: b0c2ce683687410406fa7ccdef391ff1d41503bb

--- a/files/de/web/html/reference/elements/form/index.md
+++ b/files/de/web/html/reference/elements/form/index.md
@@ -1,5 +1,5 @@
 ---
-title: "`<form>`: Das Formularelement"
+title: "<form>: Das Formularelement"
 slug: Web/HTML/Reference/Elements/form
 l10n:
   sourceCommit: c52ed787442db9d65b21f5c2874fa6bfd08a253a

--- a/files/de/web/html/reference/elements/input/week/index.md
+++ b/files/de/web/html/reference/elements/input/week/index.md
@@ -1,5 +1,5 @@
 ---
-title: '`<input type="week">`'
+title: '<input type="week">'
 slug: Web/HTML/Reference/Elements/input/week
 l10n:
   sourceCommit: 13856107d2cab5bb9e40de608ee38a5770ef7c4d

--- a/files/de/web/html/reference/global_attributes/anchor/index.md
+++ b/files/de/web/html/reference/global_attributes/anchor/index.md
@@ -1,5 +1,5 @@
 ---
-title: HTML `anchor` globales Attribut
+title: HTML anchor globales Attribut
 short-title: anchor
 slug: Web/HTML/Reference/Global_attributes/anchor
 l10n:

--- a/files/de/web/html/reference/global_attributes/autocapitalize/index.md
+++ b/files/de/web/html/reference/global_attributes/autocapitalize/index.md
@@ -1,5 +1,5 @@
 ---
-title: HTML `autocapitalize` globales Attribut
+title: HTML autocapitalize globales Attribut
 short-title: autocapitalize
 slug: Web/HTML/Reference/Global_attributes/autocapitalize
 l10n:

--- a/files/de/web/html/reference/global_attributes/autocorrect/index.md
+++ b/files/de/web/html/reference/global_attributes/autocorrect/index.md
@@ -1,5 +1,5 @@
 ---
-title: HTML `autocorrect` globales Attribut
+title: HTML autocorrect globales Attribut
 short-title: autocorrect
 slug: Web/HTML/Reference/Global_attributes/autocorrect
 l10n:

--- a/files/de/web/html/reference/global_attributes/autofocus/index.md
+++ b/files/de/web/html/reference/global_attributes/autofocus/index.md
@@ -1,5 +1,5 @@
 ---
-title: HTML `autofocus` globales Attribut
+title: HTML autofocus globales Attribut
 short-title: autofocus
 slug: Web/HTML/Reference/Global_attributes/autofocus
 l10n:

--- a/files/de/web/html/reference/global_attributes/contenteditable/index.md
+++ b/files/de/web/html/reference/global_attributes/contenteditable/index.md
@@ -1,5 +1,5 @@
 ---
-title: HTML `contenteditable` globales Attribut
+title: HTML contenteditable globales Attribut
 short-title: contenteditable
 slug: Web/HTML/Reference/Global_attributes/contenteditable
 l10n:

--- a/files/de/web/html/reference/global_attributes/data-_star_/index.md
+++ b/files/de/web/html/reference/global_attributes/data-_star_/index.md
@@ -1,5 +1,5 @@
 ---
-title: HTML `data-*` globales Attribut
+title: HTML data-* globales Attribut
 short-title: data-*
 slug: Web/HTML/Reference/Global_attributes/data-*
 l10n:

--- a/files/de/web/html/reference/global_attributes/inert/index.md
+++ b/files/de/web/html/reference/global_attributes/inert/index.md
@@ -1,5 +1,5 @@
 ---
-title: HTML `inert` globales Attribut
+title: HTML inert globales Attribut
 short-title: inert
 slug: Web/HTML/Reference/Global_attributes/inert
 l10n:

--- a/files/de/web/html/reference/global_attributes/itemref/index.md
+++ b/files/de/web/html/reference/global_attributes/itemref/index.md
@@ -1,5 +1,5 @@
 ---
-title: Globales HTML-Attribut `itemref`
+title: Globales HTML-Attribut itemref
 short-title: itemref
 slug: Web/HTML/Reference/Global_attributes/itemref
 l10n:

--- a/files/de/web/html/reference/global_attributes/spellcheck/index.md
+++ b/files/de/web/html/reference/global_attributes/spellcheck/index.md
@@ -1,5 +1,5 @@
 ---
-title: HTML `spellcheck` globales Attribut
+title: HTML spellcheck globales Attribut
 short-title: spellcheck
 slug: Web/HTML/Reference/Global_attributes/spellcheck
 l10n:

--- a/files/de/web/html/reference/global_attributes/style/index.md
+++ b/files/de/web/html/reference/global_attributes/style/index.md
@@ -1,5 +1,5 @@
 ---
-title: HTML-Attribut `style` (global)
+title: HTML-Attribut style (global)
 short-title: style
 slug: Web/HTML/Reference/Global_attributes/style
 l10n:

--- a/files/de/web/html/reference/global_attributes/title/index.md
+++ b/files/de/web/html/reference/global_attributes/title/index.md
@@ -1,5 +1,5 @@
 ---
-title: HTML-Globale Attribut `title`
+title: HTML-Globale Attribut title
 short-title: title
 slug: Web/HTML/Reference/Global_attributes/title
 l10n:

--- a/files/de/web/html/reference/global_attributes/translate/index.md
+++ b/files/de/web/html/reference/global_attributes/translate/index.md
@@ -1,5 +1,5 @@
 ---
-title: HTML `translate` Globales Attribut
+title: HTML translate Globales Attribut
 short-title: translate
 slug: Web/HTML/Reference/Global_attributes/translate
 l10n:

--- a/files/de/web/html/reference/global_attributes/virtualkeyboardpolicy/index.md
+++ b/files/de/web/html/reference/global_attributes/virtualkeyboardpolicy/index.md
@@ -1,5 +1,5 @@
 ---
-title: HTML-Attribut globales `virtualkeyboardpolicy`
+title: HTML-Attribut globales virtualkeyboardpolicy
 short-title: virtualkeyboardpolicy
 slug: Web/HTML/Reference/Global_attributes/virtualkeyboardpolicy
 l10n:

--- a/files/de/web/html/reference/global_attributes/writingsuggestions/index.md
+++ b/files/de/web/html/reference/global_attributes/writingsuggestions/index.md
@@ -1,5 +1,5 @@
 ---
-title: HTML `writingsuggestions` globales Attribut
+title: HTML writingsuggestions globales Attribut
 short-title: writingsuggestions
 slug: Web/HTML/Reference/Global_attributes/writingsuggestions
 l10n:

--- a/files/de/web/http/reference/headers/content-security-policy/default-src/index.md
+++ b/files/de/web/http/reference/headers/content-security-policy/default-src/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Content-Security-Policy: Direktive `default-src`"
+title: "Content-Security-Policy: Direktive default-src"
 short-title: default-src
 slug: Web/HTTP/Reference/Headers/Content-Security-Policy/default-src
 l10n:

--- a/files/de/web/http/reference/headers/permissions-policy/deferred-fetch-minimal/index.md
+++ b/files/de/web/http/reference/headers/permissions-policy/deferred-fetch-minimal/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Permissions-Policy: `deferred-fetch-minimal` Direktive"
+title: "Permissions-Policy: deferred-fetch-minimal Direktive"
 short-title: deferred-fetch-minimal
 slug: Web/HTTP/Reference/Headers/Permissions-Policy/deferred-fetch-minimal
 l10n:

--- a/files/de/web/http/reference/headers/permissions-policy/publickey-credentials-create/index.md
+++ b/files/de/web/http/reference/headers/permissions-policy/publickey-credentials-create/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Permissions-Policy: Directive `publickey-credentials-create`"
+title: "Permissions-Policy: Directive publickey-credentials-create"
 short-title: publickey-credentials-create
 slug: Web/HTTP/Reference/Headers/Permissions-Policy/publickey-credentials-create
 l10n:

--- a/files/de/web/http/reference/headers/permissions-policy/serial/index.md
+++ b/files/de/web/http/reference/headers/permissions-policy/serial/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Permissions-Policy: `serial` Direktive"
+title: "Permissions-Policy: serial Direktive"
 short-title: serial
 slug: Web/HTTP/Reference/Headers/Permissions-Policy/serial
 l10n:

--- a/files/de/web/http/reference/headers/permissions-policy/translator/index.md
+++ b/files/de/web/http/reference/headers/permissions-policy/translator/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Permissions-Policy: `translator`-Direktive"
+title: "Permissions-Policy: translator-Direktive"
 short-title: translator
 slug: Web/HTTP/Reference/Headers/Permissions-Policy/translator
 l10n:

--- a/files/de/web/javascript/reference/errors/stmt_after_return/index.md
+++ b/files/de/web/javascript/reference/errors/stmt_after_return/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Warnung: unerreichbarer Code nach dem `return`-Statement"
+title: "Warnung: unerreichbarer Code nach dem return-Statement"
 slug: Web/JavaScript/Reference/Errors/Stmt_after_return
 l10n:
   sourceCommit: fad67be4431d8e6c2a89ac880735233aa76c41d4

--- a/files/de/web/javascript/reference/functions/arguments/index.md
+++ b/files/de/web/javascript/reference/functions/arguments/index.md
@@ -1,5 +1,5 @@
 ---
-title: Das `arguments`-Objekt
+title: Das arguments-Objekt
 slug: Web/JavaScript/Reference/Functions/arguments
 l10n:
   sourceCommit: fad67be4431d8e6c2a89ac880735233aa76c41d4

--- a/files/de/web/javascript/reference/global_objects/iterator/iterator/index.md
+++ b/files/de/web/javascript/reference/global_objects/iterator/iterator/index.md
@@ -1,5 +1,5 @@
 ---
-title: "`Iterator()` Konstruktor"
+title: "Iterator() Konstruktor"
 short-title: Iterator()
 slug: Web/JavaScript/Reference/Global_Objects/Iterator/Iterator
 l10n:

--- a/files/de/web/javascript/reference/global_objects/regexp/regexp/index.md
+++ b/files/de/web/javascript/reference/global_objects/regexp/regexp/index.md
@@ -1,5 +1,5 @@
 ---
-title: "`RegExp()` Konstruktor"
+title: "RegExp() Konstruktor"
 short-title: RegExp()
 slug: Web/JavaScript/Reference/Global_Objects/RegExp/RegExp
 l10n:

--- a/files/de/web/javascript/reference/operators/bitwise_and_assignment/index.md
+++ b/files/de/web/javascript/reference/operators/bitwise_and_assignment/index.md
@@ -1,5 +1,5 @@
 ---
-title: Bitweises UND-Zuweisung (`&=`)
+title: Bitweises UND-Zuweisung (&=)
 slug: Web/JavaScript/Reference/Operators/Bitwise_AND_assignment
 l10n:
   sourceCommit: fad67be4431d8e6c2a89ac880735233aa76c41d4

--- a/files/de/web/javascript/reference/operators/bitwise_or_assignment/index.md
+++ b/files/de/web/javascript/reference/operators/bitwise_or_assignment/index.md
@@ -1,5 +1,5 @@
 ---
-title: Bitweises OR-Zuweisung (`|=`)
+title: Bitweises OR-Zuweisung (|=)
 slug: Web/JavaScript/Reference/Operators/Bitwise_OR_assignment
 l10n:
   sourceCommit: fad67be4431d8e6c2a89ac880735233aa76c41d4

--- a/files/de/web/media/guides/audio_and_video_delivery/webaudio_playbackrate_explained/index.md
+++ b/files/de/web/media/guides/audio_and_video_delivery/webaudio_playbackrate_explained/index.md
@@ -1,5 +1,5 @@
 ---
-title: Web-Audio-`playbackRate` erklärt
+title: Web-Audio-playbackRate erklärt
 slug: Web/Media/Guides/Audio_and_video_delivery/WebAudio_playbackRate_explained
 l10n:
   sourceCommit: 6036cd414b2214f85901158bdf3e3a96123d4553


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Removes backticks from titles in frontmatter.

Except in two cases where the original title has some:
1. RegExp.leftContext ($`)
2. SyntaxError: cannot use `??` unparenthesized within `||` and `&&` expressions

### Motivation

Avoid confusion, as backticks in titles have no effect i.e., they get rendered as backticks.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
