### PR TITLE
fix: typo in 'Weghlassen' to 'Weglassen'

### DIFF
--- a/files/de/web/html/reference/elements/aside/index.md
+++ b/files/de/web/html/reference/elements/aside/index.md
@@ -106,7 +106,7 @@ Dieses Beispiel verwendet `<aside>`, um einen Paragraphen in einem Artikel zu ke
       </td>
     </tr>
     <tr>
-      <th scope="row">Weghlassen von Tags</th>
+      <th scope="row">Weglassen von Tags</th>
       <td>Keine, sowohl das Start- als auch das End-Tag sind obligatorisch.</td>
     </tr>
     <tr>


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Fixed a typo in a table header by correcting **“Weghlassen”** to **“Weglassen”**.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

This change improves spelling accuracy and readability in the German MDN documentation, ensuring correct and professional language for readers.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

No functional changes; this is a minor editorial correction.

https://developer.mozilla.org/de/docs/Web/HTML/Reference/Elements/aside

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

N/A

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
