### PR TITLE
chore(deps): bump npm from 11.6.2 to 11.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,5 +44,5 @@
   "devDependencies": {
     "lefthook": "^2.0.14"
   },
-  "packageManager": "npm@11.6.2"
+  "packageManager": "npm@11.7.0"
 }


### PR DESCRIPTION
### Description

Updates the `packageManager` field in `package.json` from `npm@11.6.2` to `npm@11.7.0`.

### Motivation

Ensures repositories use the latest npm version.

### Additional details

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1205.