### PR TITLE
chore(de): replace localized macro names

### DIFF
--- a/files/de/.markdownlint.jsonc
+++ b/files/de/.markdownlint.jsonc
@@ -241,6 +241,27 @@
         "replace": "$1-$2",
         "searchScope": "text",
       },
+      {
+        "name": "macro-specifications",
+        "message": "Use `{{Specifications}}` instead of `{{Spezifikationen}}`",
+        "searchPattern": "/\\{\\{Spezifikationen(\\(.*?\\))?\\}\\}/gi",
+        "replace": "{{Specifications$1}}",
+        "searchScope": "text",
+      },
+      {
+        "name": "macro-compat",
+        "message": "Use `{{Compat}}` instead of `{{Kompatibilität}}`",
+        "searchPattern": "/\\{\\{Kompatibilität(\\(.*?\\))?\\}\\}/gi",
+        "replace": "{{Compat$1}}",
+        "searchScope": "text",
+      },
+      {
+        "name": "macro-deprecated-inline",
+        "message": "Use `{{deprecated_inline}}` instead of `{{veraltet_inline}}`",
+        "searchPattern": "/\\{\\{veraltet_inline(\\(.*?\\))?\\}\\}/gi",
+        "replace": "{{deprecated_inline$1}}",
+        "searchScope": "text",
+      },
     ],
   },
   // Disabled in de, because table formatting isn't that important here.

--- a/files/de/web/css/guides/selectors/index.md
+++ b/files/de/web/css/guides/selectors/index.md
@@ -204,7 +204,7 @@ Das CSS-Selektoren-Modul führt auch die {{CSSXref(":blank")}}, {{CSSXref(":curr
 
 ## Spezifikationen
 
-{{Spezifikationen}}
+{{Specifications}}
 
 ## Siehe auch
 

--- a/files/de/web/css/reference/at-rules/index.md
+++ b/files/de/web/css/reference/at-rules/index.md
@@ -25,7 +25,7 @@ l10n:
   - {{cssxref("@counter-style/symbols")}}
   - {{cssxref("@counter-style/system")}}
 - {{cssxref("@custom-media")}}
-- {{cssxref("@document")}} {{non-standard_inline}} {{veraltet_inline}}
+- {{cssxref("@document")}} {{non-standard_inline}} {{deprecated_inline}}
 - {{cssxref("@font-face")}}
   - {{cssxref("@font-face/ascent-override")}}
   - {{cssxref("@font-face/descent-override")}}

--- a/files/de/web/javascript/reference/global_objects/temporal/plainyearmonth/calendarid/index.md
+++ b/files/de/web/javascript/reference/global_objects/temporal/plainyearmonth/calendarid/index.md
@@ -43,11 +43,11 @@ console.log(newYM2.year, newYM2.monthCode); // 2021 "M06"
 
 ## Spezifikationen
 
-{{Spezifikationen}}
+{{Specifications}}
 
 ## Browser-Kompatibilität
 
-{{Kompatibilität}}
+{{Compat}}
 
 ## Siehe auch
 

--- a/files/de/web/javascript/reference/statements/import/with/index.md
+++ b/files/de/web/javascript/reference/statements/import/with/index.md
@@ -185,11 +185,11 @@ Beachten Sie, dass, wie bei statischen Importen, dynamische Importe für die Leb
 
 ## Spezifikationen
 
-{{Spezifikationen}}
+{{Specifications}}
 
 ## Browser-Kompatibilität
 
-{{Kompatibilität}}
+{{Compat}}
 
 ## Siehe auch
 


### PR DESCRIPTION
### Description

Update markdownlint config to flag and auto-fix three German macro names that should use their canonical English equivalents:

- `{{Spezifikationen}}` → `{{Specifications}}`
- `{{Kompatibilität}}` → `{{Compat}}`
- `{{veraltet_inline}}` → `{{deprecated_inline}}`

Patterns are case-insensitive and preserve macro arguments via a captured group.

### Motivation

Prevent localized macro names — which Rari does not resolve — from sneaking into translated content, and convert the existing occurrences.

### Additional details

The fixes commit was produced by running `markdownlint-cli2 --fix` on the four affected files after adding the rules.