### PR TITLE
fix: pin npx autocorrect, fred-ssr, and rari to their packages

### DIFF
--- a/.github/workflows/auto-cleanup-bot.yml
+++ b/.github/workflows/auto-cleanup-bot.yml
@@ -82,7 +82,7 @@ jobs:
           git diff HEAD --color=always --word-diff --word-diff-regex='[[:alnum:]_]+'
 
       - name: Autocorrect
-        run: ls -d 2>/dev/null "files/${{ matrix.lang }}" "docs/${{ matrix.lang }}" | xargs npx autocorrect --fix
+        run: ls -d 2>/dev/null "files/${{ matrix.lang }}" "docs/${{ matrix.lang }}" | xargs npx autocorrect-node --fix
 
       - name: Diff
         run: |

--- a/.github/workflows/pr-check-lint_content.yml
+++ b/.github/workflows/pr-check-lint_content.yml
@@ -168,7 +168,7 @@ jobs:
           DIFF_DOCUMENTS: ${{ steps.check.outputs.DIFF_DOCUMENTS }}
         run: |
           readarray -t files_to_lint <<< "$DIFF_DOCUMENTS"
-          npx autocorrect --fix "${files_to_lint[@]}"
+          npx autocorrect-node --fix "${files_to_lint[@]}"
 
       - name: Diff
         if: steps.check.outputs.HAS_FILES == 'true'

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -179,10 +179,10 @@ jobs:
               ARGS+=("-f" "$CONTENT_TRANSLATED_ROOT/$file_without_prefix")
           done
 
-          npx rari build --no-basic --json-issues --data-issues "${ARGS[@]}"
+          npx @mdn/rari build --no-basic --json-issues --data-issues "${ARGS[@]}"
 
           cp -vR node_modules/@mdn/fred/out/. "$BUILD_OUT_ROOT"
-          npx fred-ssr
+          npx --package=@mdn/fred fred-ssr
 
           echo "Disk usage size of the build"
           du -sh $BUILD_OUT_ROOT

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -8,7 +8,7 @@ pre-commit:
 
     - name: Autocorrect zh-cn
       glob: "{docs,files}/zh-cn/*.md"
-      run: npx autocorrect --fix {staged_files}
+      run: npx autocorrect-node --fix {staged_files}
       stage_fixed: true
 
     - name: Fix markdown

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
   "type": "module",
   "scripts": {
     "fix:json": "prettier -w \"**/*.json(c)?\"",
-    "fix:md": "markdownlint-cli2 --fix \"**/*.md\" && node ./scripts/check-url-locale.js --fix files && npx autocorrect --fix . && prettier -w \"**/*.md\"",
+    "fix:md": "markdownlint-cli2 --fix \"**/*.md\" && node ./scripts/check-url-locale.js --fix files && npx autocorrect-node --fix . && prettier -w \"**/*.md\"",
     "fix:yml": "prettier -w \"**/*.yml\"",
     "lint:json": "prettier -c \"**/*.json(c)?\"",
-    "lint:md": "markdownlint-cli2 \"**/*.md\" && node ./scripts/check-url-locale.js files && npx autocorrect --lint . && prettier -c \"**/*.md\"",
+    "lint:md": "markdownlint-cli2 \"**/*.md\" && node ./scripts/check-url-locale.js files && npx autocorrect-node --lint . && prettier -c \"**/*.md\"",
     "lint:yml": "prettier -c \"**/*.yml\"",
     "test": "node --test"
   },


### PR DESCRIPTION
### Description

Pin bare `npx` binary invocations to their providing packages so they can't fall back to a registry name:

- `npx autocorrect …` → `npx autocorrect-node …` (workflows, `.lefthook.yml`, `package.json`)
- `npx fred-ssr` → `npx --package=@mdn/fred fred-ssr` (`.github/workflows/pr-test.yml`)
- `npx rari …` → `npx @mdn/rari …` (`.github/workflows/pr-test.yml`)

### Motivation

Prevent dependency-confusion fallbacks where `npx` silently fetches a squattable or unrelated registry package.

### Additional details

`npx <bin>` resolves to the local bin only when present; otherwise npm silently downloads and runs a registry package literally named `<bin>`. In CI and lefthook hooks, `npx` assumes `--yes`, so the fetch happens with no prompt. The bare `autocorrect` name on npm is an unrelated string-matching library (the intended linter is `autocorrect-node`, already a pinned dependency); `fred-ssr` is a bin of `@mdn/fred` whose bare name is unpublished/squattable; the unscoped `rari` name is owned by an unrelated third party, not MDN. Naming each provider explicitly guarantees the intended bin.

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1680.
