### PR TITLE
ci(dependabot): refine commit prefixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,15 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+    commit-message:
+      prefix: chore
+      prefix-development: build
+      include: scope
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: weekly
     commit-message:
-      prefix: "ci(deps): "
+      prefix: ci
+      include: scope


### PR DESCRIPTION
### Description

Update the Dependabot config to refine the commit prefixes:

- Prefix npm updates with `chore` (and `build` for dev dependencies), with scope.
- Prefix GitHub Actions updates with `ci`, with scope.

### Motivation

Avoid that npm packages get the `ci(deps)` prefix.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Same as https://github.com/mdn/content/pull/44730 and https://github.com/mdn/translated-content/pull/37058.