### PR TITLE
docs(webassembly): replace `npm adduser` with `npm login`

### DIFF
--- a/files/de/webassembly/guides/rust_to_wasm/index.md
+++ b/files/de/webassembly/guides/rust_to_wasm/index.md
@@ -394,7 +394,7 @@ hello-wasm-0.1.0.tgz
 [INFO]: 🎒  packed up your package!
 ```
 
-Um auf npm zu veröffentlichen, benötigen Sie ein [npm-Konto](https://www.npmjs.com/) und müssen Ihre Maschine mit [`npm adduser`](https://docs.npmjs.com/cli/v10/commands/npm-adduser/) autorisieren.
+Um auf npm zu veröffentlichen, benötigen Sie ein [npm-Konto](https://www.npmjs.com/) und müssen Ihre Maschine mit [`npm login`](https://docs.npmjs.com/cli/v11/commands/npm-login/) autorisieren.
 Wenn Sie bereit sind, können Sie mit `wasm-pack` veröffentlichen, das unter der Haube `npm publish` aufruft:
 
 ```bash


### PR DESCRIPTION
### Description

Update the Rust to Wasm guide to use `npm login` instead of `npm adduser`.

### Motivation

`npm adduser` was removed in npm 12, so readers are told to run a command that no longer exists.

### Additional details

`npm login` has been the documented alias for years, so this is a rename rather than a change in instructions. The link now points at `npm-login` in the current (v11) CLI docs instead of `npm-adduser` in the v10 docs.

### Related issues and pull requests

Part of mdn/fred#1868.
