### PR TITLE
ci(slash-commands): add `/translate` command to trigger on-demand translations

### DIFF
--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -1,0 +1,34 @@
+name: Slash commands
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  # Add the 👀 reaction to the triggering comment.
+  issues: write
+  pull-requests: write
+
+jobs:
+  translate:
+    # Fires for both issue and PR comments, and runs on the default branch,
+    # so PR code cannot influence it.
+    if: startsWith(github.event.comment.body, '/translate')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peter-evans/slash-command-dispatch@9bdcd7914ec1b75590b790b844aa3b8eee7c683a # v5.0.2
+        with:
+          # Needs `actions: write` on the translator repository (workflow_dispatch).
+          token: ${{ secrets.MDN_BOT_PAT }}
+          reaction-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: mdn/private-locale-translator
+          commands: translate
+          permission: write
+          issue-type: both
+          dispatch-type: workflow
+          # Targets `translate-command.yml` (command + `-command` suffix) in the
+          # translator repository. Named args become workflow inputs, e.g.
+          #   /translate slugs=Web/CSS/color,Web/API/Fetch_API/* force=true
+          #   /translate resume=<run-id>   (after a timeout, see the bot's reply)
+          static-args: |
+            issue-url=${{ github.event.issue.html_url }}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Add a `slash-commands.yml` workflow that lets maintainers with write access trigger the translation of individual pages or areas by commenting on an issue or PR:

```
/translate slugs=Web/CSS/color,Web/API/Fetch_API/* force=true
```

Appending `/*` selects all subpages instead of the page itself. The command dispatches the `Translate (on demand)` workflow (`translate-command.yml`) in the translator repository, which replies to the issue/PR with the resulting commit or a failure notice. If the batch does not finish within the time limit, the reply includes a `/translate resume=<run-id>` command to pick it up later.

### Motivation

Make it easier to translate specific pages on demand (e.g. after a content fix or when reviewing a PR), instead of waiting for the scheduled run.

### Additional details

Requires a `MDN_BOT_PAT` repository secret with `actions: write` on the translator repository. The reaction on the triggering comment uses the default `GITHUB_TOKEN`.

The workflow runs on the default branch via `issue_comment`, so PR code cannot influence it, and `permission: write` restricts it to maintainers.

### Related issues and pull requests

**Depends on:** mdn/private-locale-translator#346
